### PR TITLE
Add a few more Netscaler options

### DIFF
--- a/library/netscaler_lbmonitor.py
+++ b/library/netscaler_lbmonitor.py
@@ -199,6 +199,14 @@ options:
     required: false
     default: 2
     type: int
+  retries:
+    description:
+      - Maximum number of probes to send to establish the state of a service for which a monitoring probe failed.
+      - Minimum value = 1
+      - Maximum value = 127
+    required: false
+    default: 3
+    type: int
 '''
 
 EXAMPLES = '''
@@ -962,7 +970,8 @@ def main():
         recv=dict(required=False, type="str"),
         lrtm=dict(choices=["ENABLED", "DISABLED"], required=False, type="str"),
         interval=dict(default=5,required=False, type="int"),
-        resptimeout=dict(default=2,required=False, type="int")
+        resptimeout=dict(default=2,required=False, type="int"),
+        retries=dict(default=3,required=False, type="int")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -993,6 +1002,7 @@ def main():
     lrtm = module.params["lrtm"]
     interval = module.params["interval"]
     resptimeout = module.params["resptimeout"]
+    retries = module.params["retries"]
     if response_code:
         response_code = [str(code).strip() for code in response_code]
 
@@ -1013,7 +1023,8 @@ def main():
         recv = module.params["recv"],
         lrtm = module.params["lrtm"],
         interval = module.params["interval"],
-        resptimeout = module.params["resptimeout"]
+        resptimeout = module.params["resptimeout"],
+        retries = module.params["retries"]
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args

--- a/library/netscaler_lbmonitor.py
+++ b/library/netscaler_lbmonitor.py
@@ -167,6 +167,11 @@ options:
     type: str
     default: add
     choices: ["add", "remove"]
+  send:
+    description:
+      - String to send to the service. Applicable to TCP-ECV, HTTP-ECV, and UDP-ECV monitors.
+    required: false
+    type: str
 '''
 
 EXAMPLES = '''
@@ -925,7 +930,8 @@ def main():
         monitor_use_ssl=dict(choices=["YES", "NO"], required=False, type="str"),
         monitor_username=dict(required=False, type="str"),
         response_code=dict(required=False, type="list"),
-        response_code_action=dict(choices=["add", "remove"], required=False, type="str", default="add")
+        response_code_action=dict(choices=["add", "remove"], required=False, type="str", default="add"),
+        send=dict(required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -951,6 +957,7 @@ def main():
     validate_certs = module.params["validate_certs"]
     response_code_action = module.params["response_code_action"]
     response_code = module.params["response_code"]
+    send = module.params["send"]
     if response_code:
         response_code = [str(code).strip() for code in response_code]
 

--- a/library/netscaler_lbmonitor.py
+++ b/library/netscaler_lbmonitor.py
@@ -172,6 +172,11 @@ options:
       - String to send to the service. Applicable to TCP-ECV, HTTP-ECV, and UDP-ECV monitors.
     required: false
     type: str
+  recv:
+    description:
+      - String expected from the server for the service to be marked as UP. Applicable to TCP-ECV, HTTP-ECV, and UDP-ECV monitors.
+    required: false
+    type: str
 '''
 
 EXAMPLES = '''
@@ -931,7 +936,8 @@ def main():
         monitor_username=dict(required=False, type="str"),
         response_code=dict(required=False, type="list"),
         response_code_action=dict(choices=["add", "remove"], required=False, type="str", default="add"),
-        send=dict(required=False, type="str")
+        send=dict(required=False, type="str"),
+        recv=dict(required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -958,6 +964,7 @@ def main():
     response_code_action = module.params["response_code_action"]
     response_code = module.params["response_code"]
     send = module.params["send"]
+    recv = module.params["recv"]
     if response_code:
         response_code = [str(code).strip() for code in response_code]
 

--- a/library/netscaler_lbmonitor.py
+++ b/library/netscaler_lbmonitor.py
@@ -177,6 +177,14 @@ options:
       - String expected from the server for the service to be marked as UP. Applicable to TCP-ECV, HTTP-ECV, and UDP-ECV monitors.
     required: false
     type: str
+  lrtm:
+    description:
+      - Calculate the least response times for bound services.
+      - If this parameter is not enabled, the appliance does not learn the response times of the bound services.
+      - Also used for LRTM load balancing.
+    required: false
+    type: str
+    choices: ["ENABLED", "DISABLED"]
 '''
 
 EXAMPLES = '''
@@ -937,7 +945,8 @@ def main():
         response_code=dict(required=False, type="list"),
         response_code_action=dict(choices=["add", "remove"], required=False, type="str", default="add"),
         send=dict(required=False, type="str"),
-        recv=dict(required=False, type="str")
+        recv=dict(required=False, type="str"),
+        lrtm=dict(choices=["ENABLED", "DISABLED"], required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -965,6 +974,7 @@ def main():
     response_code = module.params["response_code"]
     send = module.params["send"]
     recv = module.params["recv"]
+    lrtm = module.params["lrtm"]
     if response_code:
         response_code = [str(code).strip() for code in response_code]
 

--- a/library/netscaler_lbmonitor.py
+++ b/library/netscaler_lbmonitor.py
@@ -990,7 +990,10 @@ def main():
         secure=module.params["monitor_use_ssl"],
         state=module.params["monitor_state"].upper(),
         type=module.params["monitor_type"],
-        username=module.params["monitor_username"]
+        username=module.params["monitor_username"],
+        send = module.params["send"],
+        recv = module.params["recv"],
+        lrtm = module.params["lrtm"]
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args

--- a/library/netscaler_lbmonitor.py
+++ b/library/netscaler_lbmonitor.py
@@ -997,12 +997,7 @@ def main():
     validate_certs = module.params["validate_certs"]
     response_code_action = module.params["response_code_action"]
     response_code = module.params["response_code"]
-    send = module.params["send"]
-    recv = module.params["recv"]
-    lrtm = module.params["lrtm"]
-    interval = module.params["interval"]
-    resptimeout = module.params["resptimeout"]
-    retries = module.params["retries"]
+
     if response_code:
         response_code = [str(code).strip() for code in response_code]
 

--- a/library/netscaler_lbmonitor.py
+++ b/library/netscaler_lbmonitor.py
@@ -191,7 +191,6 @@ options:
     required: false
     default: 5
     type: int
-    choices: ["ENABLED", "DISABLED"]
   resptimeout:
     description:
       - Amount of time for which the appliance must wait before it marks a probe as FAILED. Must be less than the value specified for the Interval parameter.

--- a/library/netscaler_lbmonitor.py
+++ b/library/netscaler_lbmonitor.py
@@ -192,6 +192,14 @@ options:
     default: 5
     type: int
     choices: ["ENABLED", "DISABLED"]
+  resptimeout:
+    description:
+      - Amount of time for which the appliance must wait before it marks a probe as FAILED. Must be less than the value specified for the Interval parameter.
+      - Minimum value = 1
+      - Maximum value = 20939
+    required: false
+    default: 2
+    type: int
 '''
 
 EXAMPLES = '''
@@ -954,7 +962,8 @@ def main():
         send=dict(required=False, type="str"),
         recv=dict(required=False, type="str"),
         lrtm=dict(choices=["ENABLED", "DISABLED"], required=False, type="str"),
-        interval=dict(default=5,required=False, type="int")
+        interval=dict(default=5,required=False, type="int"),
+        resptimeout=dict(default=2,required=False, type="int")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -984,6 +993,7 @@ def main():
     recv = module.params["recv"]
     lrtm = module.params["lrtm"]
     interval = module.params["interval"]
+    resptimeout = module.params["resptimeout"]
     if response_code:
         response_code = [str(code).strip() for code in response_code]
 
@@ -1003,7 +1013,8 @@ def main():
         send = module.params["send"],
         recv = module.params["recv"],
         lrtm = module.params["lrtm"],
-        interval = module.params["interval"]
+        interval = module.params["interval"],
+        resptimeout = module.params["resptimeout"]
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args

--- a/library/netscaler_lbmonitor.py
+++ b/library/netscaler_lbmonitor.py
@@ -185,6 +185,13 @@ options:
     required: false
     type: str
     choices: ["ENABLED", "DISABLED"]
+  interval:
+    description:
+      - Time interval between two successive probes. Must be greater than the value of Response Time-out.
+    required: false
+    default: 5
+    type: int
+    choices: ["ENABLED", "DISABLED"]
 '''
 
 EXAMPLES = '''
@@ -946,7 +953,8 @@ def main():
         response_code_action=dict(choices=["add", "remove"], required=False, type="str", default="add"),
         send=dict(required=False, type="str"),
         recv=dict(required=False, type="str"),
-        lrtm=dict(choices=["ENABLED", "DISABLED"], required=False, type="str")
+        lrtm=dict(choices=["ENABLED", "DISABLED"], required=False, type="str"),
+        interval=dict(default=5,required=False, type="int")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -975,6 +983,7 @@ def main():
     send = module.params["send"]
     recv = module.params["recv"]
     lrtm = module.params["lrtm"]
+    interval = module.params["interval"]
     if response_code:
         response_code = [str(code).strip() for code in response_code]
 
@@ -993,7 +1002,8 @@ def main():
         username=module.params["monitor_username"],
         send = module.params["send"],
         recv = module.params["recv"],
-        lrtm = module.params["lrtm"]
+        lrtm = module.params["lrtm"],
+        interval = module.params["interval"]
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args

--- a/library/netscaler_lbvserver.py
+++ b/library/netscaler_lbvserver.py
@@ -762,10 +762,10 @@ class LBVServer(Netscaler):
         port = proposed["port"]
 
         colliding_lbvserver_dict = {}
-        colliding_lbvserver = self.get_lbvserver_by_ip_td_port(ip_address, traffic_domain, port)
+        colliding_lbvserver = self.get_lbvserver_by_ip_td_servicetype(ip_address, traffic_domain, service_type)
 
-        if colliding_lbvserver:
-            colliding_lbvserver = self.get_lbvserver_by_ip_td_servicetype(ip_address, traffic_domain, service_type)
+        if not colliding_lbvserver:
+            colliding_lbvserver = self.get_lbvserver_by_ip_td_port(ip_address, traffic_domain, port)
 
         if colliding_lbvserver:
             colliding_lbvserver_dict["proposed_name"] = proposed["name"]

--- a/library/netscaler_lbvserver.py
+++ b/library/netscaler_lbvserver.py
@@ -762,10 +762,10 @@ class LBVServer(Netscaler):
         port = proposed["port"]
 
         colliding_lbvserver_dict = {}
-        colliding_lbvserver = self.get_lbvserver_by_ip_td_servicetype(ip_address, traffic_domain, service_type)
+        colliding_lbvserver = self.get_lbvserver_by_ip_td_port(ip_address, traffic_domain, port)
 
-        if not colliding_lbvserver:
-            colliding_lbvserver = self.get_lbvserver_by_ip_td_port(ip_address, traffic_domain, port)
+        if colliding_lbvserver:
+            colliding_lbvserver = self.get_lbvserver_by_ip_td_servicetype(ip_address, traffic_domain, service_type)
 
         if colliding_lbvserver:
             colliding_lbvserver_dict["proposed_name"] = proposed["name"]

--- a/library/netscaler_lbvserver.py
+++ b/library/netscaler_lbvserver.py
@@ -161,6 +161,13 @@ options:
     choices: ["HTTP", "FTP", "TCP", "UDP", "SSL", "SSL_BRIDGE", "SSL_TCP", "DTLS", "NNTP", "DNS", "DHCPRA", "ANY",
               "SIP_UDP", "SIP_TCP", "SIP_SSL", "DNS_TCP", "RTSP", "PUSH", "SSL_PUSH", "RADIUS", "RDP", "MYSQL",
               "MSSQL", "DIAMETER", "SSL_DIAMETER", "TFTP", "ORACLE", "SMPP", "SYSLOGTCP", "SYSLOGUDP", "FIX"]
+  app_flow_log:
+    description:
+      - Enable logging of AppFlow information for the specified service group.
+    required: false
+    type: str
+    choices: ["DISABLED", "ENABLED"]
+    default: "ENABLED"
   traffic_domain:
     description:
       - The traffic domain associated with the servicegroup
@@ -993,6 +1000,7 @@ def main():
         lbvserver_state=dict(choices=["disabled", "enabled"], required=False, type="str", default="enabled"),
         persistence=dict(choices=VALID_PERSISTENCE_TYPES, required=False, type="str"),
         service_type=dict(choices=VALID_SERVICETYPES, required=False, type="str"),
+        app_flow_log=dict(choices=["ENABLED", "DISABLED"], required=False, type="str", default="ENABLED"),
         traffic_domain=dict(required=False, type="str", default="0"),
     )
 
@@ -1031,6 +1039,7 @@ def main():
         state=module.params["lbvserver_state"].upper(),
         persistencetype=module.params["persistence"],
         servicetype=module.params["service_type"],
+        appflowlog=module.params["app_flow_log"],
         td=module.params["traffic_domain"]
     )
 

--- a/library/netscaler_lbvserver.py
+++ b/library/netscaler_lbvserver.py
@@ -993,13 +993,6 @@ class LBVServer(Netscaler):
 
 VALID_APP_FLOW = ["DISABLED", "ENABLED", "enabled", "disabled"]
 VALID_CONN_FAILOVER = ["DISABLED", "STATEFUL", "STATELESS", "disabled", "stateful", "stateless"]
-VALID_SERVICETYPES = ["HTTP", "FTP", "TCP", "UDP", "SSL", "SSL_BRIDGE", "SSL_TCP", "DTLS", "NNTP", "DNS", "DHCPRA",
-                      "ANY", "SIP_UDP", "SIP_TCP", "SIP_SSL", "DNS_TCP", "RTSP", "PUSH", "SSL_PUSH", "RADIUS", "RDP",
-                      "MYSQL", "MSSQL", "DIAMETER", "SSL_DIAMETER", "TFTP", "ORACLE", "SMPP", "SYSLOGTCP", "SYSLOGUDP",
-                      "FIX", "http", "ftp", "tcp", "udp", "ssl", "ssl_bridge", "ssl_tcp", "dtls", "nntp", "dns", "dhcpra",
-                      "any", "sip_udp", "sip_tcp", "sip_ssl", "dns_tcp", "rtsp", "push", "ssl_push", "radius", "rdp",
-                      "mysql", "mssql", "diameter", "ssl_diameter", "tftp", "oracle", "smpp", "syslogtcp", "syslogudp",
-                      "fix"]
 VALID_LBMETHODS = ["ROUNDROBIN", "LEASTCONNECTION", "LEASTRESPONSETIME", "URLHASH", "DOMAINHASH", "DESTINATIONIPHASH",
                    "SOURCEIPHASH", "SRCIPDESTIPHASH", "LEASTBANDWIDTH", "LEASTPACKETS", "TOKEN", "SRCIPSRCPORTHASH",
                    "LRTM", "CALLIDHASH", "CUSTOMLOAD", "LEASTREQUEST", "AUDITLOGHASH", "STATICPROXIMITY", "roundrobin",
@@ -1010,6 +1003,14 @@ VALID_PERSISTENCE_TYPES = ["SOURCEIP", "COOKIEINSERT", "SSLSESSION", "RULE", "UR
                            "SRCIPDESTIP", "CALLID", "RTSPSID", "DIAMETER", "FIXSESSION", "NONE", "sourceip", "cookieinsert",
                            "sslsession", "rule", "urlpassive", "customserverid", "destip", "srcipdestip", "callid", "rtspsid",
                            "diameter", "fixsession", "none"]
+VALID_SERVICETYPES = ["HTTP", "FTP", "TCP", "UDP", "SSL", "SSL_BRIDGE", "SSL_TCP", "DTLS", "NNTP", "DNS", "DHCPRA",
+                      "ANY", "SIP_UDP", "SIP_TCP", "SIP_SSL", "DNS_TCP", "RTSP", "PUSH", "SSL_PUSH", "RADIUS", "RDP",
+                      "MYSQL", "MSSQL", "DIAMETER", "SSL_DIAMETER", "TFTP", "ORACLE", "SMPP", "SYSLOGTCP", "SYSLOGUDP",
+                      "FIX", "http", "ftp", "tcp", "udp", "ssl", "ssl_bridge", "ssl_tcp", "dtls", "nntp", "dns", "dhcpra",
+                      "any", "sip_udp", "sip_tcp", "sip_ssl", "dns_tcp", "rtsp", "push", "ssl_push", "radius", "rdp",
+                      "mysql", "mssql", "diameter", "ssl_diameter", "tftp", "oracle", "smpp", "syslogtcp", "syslogudp",
+                      "fix"]
+
 
 def main():
     argument_spec = dict(
@@ -1098,6 +1099,7 @@ def main():
         traffic_domain = "0"
 
     args = dict(
+        appflowlog=app_flow_log,
         backupvserver=module.params["backup_lbvserver"],
         clttimeout=client_timeout,
         comment=module.params["comment"],
@@ -1110,7 +1112,6 @@ def main():
         state=lbvserver_state,
         persistencetype=persistence,
         servicetype=service_type,
-        appflowlog=app_flow_log,
         td=traffic_domain
     )
 

--- a/library/netscaler_lbvserver.py
+++ b/library/netscaler_lbvserver.py
@@ -89,6 +89,7 @@ options:
   app_flow_log:
     description:
       - Enable logging of AppFlow information for the specified service group.
+      
     required: false
     type: str
     choices: ["disabled", "enabled"]
@@ -1035,7 +1036,7 @@ def main():
         lbvserver_state=dict(choices=["disabled", "enabled"], required=False, type="str"),
         persistence=dict(choices=VALID_PERSISTENCE_TYPES, required=False, type="str"),
         service_type=dict(choices=VALID_SERVICETYPES, required=False, type="str"),
-        traffic_domain=dict(required=False, type="str", default="0")
+        traffic_domain=dict(required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)

--- a/library/netscaler_servicegroup.py
+++ b/library/netscaler_servicegroup.py
@@ -161,6 +161,7 @@ options:
       - Use client's IP address as the source IP address when initiating connection to the server.
     required: false
     type: str
+    choices: ["YES", "NO"]
     default: "NO"
   useproxyport:
     description:

--- a/library/netscaler_servicegroup.py
+++ b/library/netscaler_servicegroup.py
@@ -144,6 +144,12 @@ options:
     required: false
     type: str
     default: "0"
+  cka:
+    description:
+      - Enable client keep-alive for the service group.
+    required: false
+    type: str
+    choices: ["YES", "NO"]
 '''
 
 EXAMPLES = '''
@@ -941,7 +947,8 @@ def main():
         service_type=dict(choices=VALID_SERVICETYPES, required=False, type="str"),
         servicegroup_name=dict(required=True, type="str"),
         servicegroup_state=dict(choices=["disabled", "enabled"], default="enabled", type="str"),
-        traffic_domain=dict(required=False, type="str", default="0")
+        traffic_domain=dict(required=False, type="str", default="0"),
+        cka=dict(choices=["YES","NO"], required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -975,7 +982,8 @@ def main():
         servicetype=module.params["service_type"],
         servicegroupname=module.params["servicegroup_name"],
         state=module.params["servicegroup_state"].upper(),
-        td=module.params["traffic_domain"]
+        td=module.params["traffic_domain"],
+        cka=module.params["cka"]
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args

--- a/library/netscaler_servicegroup.py
+++ b/library/netscaler_servicegroup.py
@@ -156,6 +156,11 @@ options:
     required: false
     type: str
     choices: ["ENABLED", "DISABLED"]
+  cipheader:
+    description:
+      - Name of the HTTP header whose value must be set to the IP address of the client. Used with the Client IP parameter.
+    required: false
+    type: str
   usip:
     description:
       - Use client's IP address as the source IP address when initiating connection to the server.
@@ -983,6 +988,7 @@ def main():
         traffic_domain=dict(required=False, type="str", default="0"),
         cka=dict(choices=["YES","NO"], required=False, type="str"),
         cip=dict(choices=["ENABLED","DISABLED"], required=False, type="str"),
+        cipheader=dict(required=False, type="str"),
         usip=dict(choices=["YES","NO"], required=False, type="str", default="NO"),
         useproxyport=dict(choices=["YES","NO"], required=False, type="str"),
         tcpb=dict(choices=["YES","NO"], required=False, type="str"),
@@ -1023,6 +1029,7 @@ def main():
         td=module.params["traffic_domain"],
         cka=module.params["cka"],
         cip=module.params["cip"],
+        cipheader=module.params["cipheader"],
         usip=module.params["usip"],
         useproxyport=module.params["useproxyport"],
         tcpb=module.params["tcpb"],

--- a/library/netscaler_servicegroup.py
+++ b/library/netscaler_servicegroup.py
@@ -150,6 +150,12 @@ options:
     required: false
     type: str
     choices: ["YES", "NO"]
+  cip:
+    description:
+      - Insert the Client IP header in requests forwarded to the service.
+    required: false
+    type: str
+    choices: ["ENABLED", "DISABLED"]
 '''
 
 EXAMPLES = '''
@@ -948,7 +954,8 @@ def main():
         servicegroup_name=dict(required=True, type="str"),
         servicegroup_state=dict(choices=["disabled", "enabled"], default="enabled", type="str"),
         traffic_domain=dict(required=False, type="str", default="0"),
-        cka=dict(choices=["YES","NO"], required=False, type="str")
+        cka=dict(choices=["YES","NO"], required=False, type="str"),
+        cip=dict(choices=["ENABLED","DISABLED"], required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -983,7 +990,8 @@ def main():
         servicegroupname=module.params["servicegroup_name"],
         state=module.params["servicegroup_state"].upper(),
         td=module.params["traffic_domain"],
-        cka=module.params["cka"]
+        cka=module.params["cka"],
+        cip=module.params["cip"]
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args

--- a/library/netscaler_servicegroup.py
+++ b/library/netscaler_servicegroup.py
@@ -162,6 +162,14 @@ options:
     required: false
     type: str
     default: "NO"
+  useproxyport:
+    description:
+      - Use the proxy port as the source port when initiating connections with the server.
+      - With the NO setting, the client-side connection port is used as the source port for the server-side connection.
+      - Note: This parameter is available only when the Use Source IP (USIP) parameter is set to YES.
+    required: false
+    type: str
+    choices: ["YES", "NO"]
 '''
 
 EXAMPLES = '''
@@ -962,7 +970,8 @@ def main():
         traffic_domain=dict(required=False, type="str", default="0"),
         cka=dict(choices=["YES","NO"], required=False, type="str"),
         cip=dict(choices=["ENABLED","DISABLED"], required=False, type="str"),
-        usip=dict(choices=["YES","NO"], required=False, type="str", default="NO")
+        usip=dict(choices=["YES","NO"], required=False, type="str", default="NO"),
+        useproxyport=dict(choices=["YES","NO"], required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -999,7 +1008,8 @@ def main():
         td=module.params["traffic_domain"],
         cka=module.params["cka"],
         cip=module.params["cip"],
-        usip=module.params["usip"]
+        usip=module.params["usip"],
+        useproxyport=module.params["useproxyport"],
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args

--- a/library/netscaler_servicegroup.py
+++ b/library/netscaler_servicegroup.py
@@ -86,6 +86,27 @@ options:
     required: false
     default: False
     type: bool
+  client_header:
+    description:
+      - Name of the HTTP header whose value must be set to the IP address of the client.
+      - Used with C(client_header_state).
+    aliases: ["cipheader"]
+    required: false
+    type: str
+  client_header_state:
+    description:
+      - Insert the Client IP header in requests forwarded to the service.
+    aliases: ["cip"]
+    required: false
+    type: str
+    choices: ["enabled", "disabled"]
+  client_keepalive:
+    description:
+      - Enable client keep-alive for the service group.
+    aliases: ["cka"]
+    required: false
+    type: str
+    choices: ["yes", "no"]
   client_timeout:
     description:
       - Seconds to wait before terminating a client session.
@@ -97,6 +118,13 @@ options:
       - A comment about the servicegroup.
     required: false
     type: str
+  compression:
+    description:
+      - Enable compression for the specified service.
+    aliases: ["cmp"]
+    required: false
+    type: str
+    choices: ["yes", "no"]
   max_client:
     description:
       - maximum number of simultaneous open connections
@@ -137,56 +165,35 @@ options:
       - Enabled marks it serviceable.
     required: false
     choices: ["disabled", "enabled"]
+  tcp_buffer:
+    description:
+      - Enable TCP buffering for the service group.
+    required: false
+    aliases: ["tcpb"]
+    type: str
+    choices: ["yes", "no"]
   traffic_domain:
     description:
       - The traffic domain associated with the servicegroup
     required: false
     type: str
     default: "0"
-  cka:
-    description:
-      - Enable client keep-alive for the service group.
-    required: false
-    type: str
-    choices: ["YES", "NO"]
-  cip:
-    description:
-      - Insert the Client IP header in requests forwarded to the service.
-    required: false
-    type: str
-    choices: ["ENABLED", "DISABLED"]
-  cipheader:
-    description:
-      - Name of the HTTP header whose value must be set to the IP address of the client. Used with the Client IP parameter.
-    required: false
-    type: str
-  usip:
+  use_client_ip:
     description:
       - Use client's IP address as the source IP address when initiating connection to the server.
     required: false
+    aliases: ["usip"]
     type: str
-    choices: ["YES", "NO"]
-    default: "NO"
-  useproxyport:
+    choices: ["yes", "no"]
+  use_proxy_port:
     description:
       - Use the proxy port as the source port when initiating connections with the server.
-      - With the NO setting, the client-side connection port is used as the source port for the server-side connection.
-      - Note: This parameter is available only when the Use Source IP (USIP) parameter is set to YES.
+      - When C(no), the client-side connection port is used as the source port for the server-side connection.
+      - Note: This parameter is available only when the C(usip) is C(yes).
+    aliases: ["useproxyport"]
     required: false
     type: str
-    choices: ["YES", "NO"]
-  tcpb:
-    description:
-      - Enable TCP buffering for the service group.
-    required: false
-    type: str
-    choices: ["YES", "NO"]
-  cmp:
-    description:
-      - Enable compression for the specified service.
-    required: false
-    type: str
-    choices: ["YES", "NO"]
+    choices: ["yes", "no"]
 '''
 
 EXAMPLES = '''
@@ -1147,6 +1154,7 @@ class ServiceGroup(Netscaler):
         return response
 
 
+ENABLED_DISABLED = ["ENABLED", "DISABLED", "enabled", "disabled"]
 VALID_SERVICETYPES = ["HTTP", "FTP", "TCP", "UDP", "SSL", "SSL_BRIDGE", "SSL_TCP", "DTLS", "NNTP", "RPCSVR", "DNS",
                       "ADNS", "SNMP", "RTSP", "DHCPRA", "ANY", "SIP_UDP", "SIP_TCP", "SIP_SSL", "DNS_TCP", "ADNS_TCP",
                       "MYSQL", "MSSQL", "ORACLE", "RADIUS", "RADIUSLISTENER", "RDP", "DIAMETER", "SSL_DIAMETER", "TFTP",
@@ -1155,6 +1163,7 @@ VALID_SERVICETYPES = ["HTTP", "FTP", "TCP", "UDP", "SSL", "SSL_BRIDGE", "SSL_TCP
                       "sip_udp", "sip_tcp", "sip_ssl", "dns_tcp", "adns_tcp", "mysql", "mssql", "oracle", "radius",
                       "radiuslistener", "rdp", "diameter", "ssl_diameter", "tftp", "smpp", "pptp", "gre", "syslogtcp",
                       "syslogudp", "fix"]
+YES_NO = ["YES", "NO", "yes", "no"]
 
 
 def main():
@@ -1168,22 +1177,22 @@ def main():
         provider=dict(required=False, type="dict"),
         state=dict(choices=["absent", "present"], type="str"),
         partition=dict(required=False, type="str"),
+        client_header=dict(required=False, aliases=["cipheader"], type="str"),
+        client_header_state=dict(choices=ENABLED_DISABLED, aliases=["cip"], required=False, type="str"),
+        client_keepalive=dict(choices=YES_NO, aliases=["cka"], required=False, type="str"),
         client_timeout=dict(required=False, type="int"),
         comment=dict(required=False, type="str"),
+        compression=dict(choices=YES_NO, aliases=["cmp"], required=False, type="str"),
         max_client=dict(required=False, type="str"),
         max_req=dict(required=False, type="str"),
         server_timeout=dict(required=False, type="int"),
         service_type=dict(choices=VALID_SERVICETYPES, required=False, type="str"),
-        servicegroup_name=dict(required=True, type="str"),
-        servicegroup_state=dict(required=False, choices=["disabled", "enabled"], default="enabled", type="str"),
-        traffic_domain=dict(required=False, type="str", default="0"),
-        cka=dict(choices=["YES","NO"], required=False, type="str"),
-        cip=dict(choices=["ENABLED","DISABLED"], required=False, type="str"),
-        cipheader=dict(required=False, type="str"),
-        usip=dict(choices=["YES","NO"], required=False, type="str", default="NO"),
-        useproxyport=dict(choices=["YES","NO"], required=False, type="str"),
-        tcpb=dict(choices=["YES","NO"], required=False, type="str"),
-        cmp=dict(choices=["YES","NO"], required=False, type="str")
+        servicegroup_name=dict(required=False, type="str"),
+        servicegroup_state=dict(required=False, choices=ENABLED_DISABLED, type="str"),
+        tcp_buffer=dict(choices=YES_NO, aliases=["tcpb"], required=False, type="str"),
+        traffic_domain=dict(required=False, type="str"),
+        use_client_ip=dict(choices=YES_NO, aliases=["usip"], required=False, type="str"),
+        use_proxy_port=dict(choices=YES_NO, aliases=["useproxyport"], required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -1214,9 +1223,18 @@ def main():
     validate_certs = module.params["validate_certs"]
     if validate_certs is None:
         validate_certs = False
+    client_header_state = module.params["client_header_state"]
+    if client_header_state:
+        client_header_state = client_header_state.upper()
+    client_keepalive = module.params["client_keepalive"]
+    if client_keepalive:
+        client_keepalive = client_keepalive.upper()
     client_timeout = module.params["client_timeout"]
     if client_timeout:
         client_timeout = int(client_timeout)
+    compression = module.params["compression"]
+    if compression:
+        compression = compression.upper()
     max_client = module.params["max_client"]
     if max_client:
         max_client = str(max_client)
@@ -1232,15 +1250,27 @@ def main():
     servicegroup_state = module.params["servicegroup_state"]
     if servicegroup_state:
         servicegroup_state = servicegroup_state.upper()
+    tcp_buffer = module.params["tcp_buffer"]
+    if tcp_buffer:
+        tcp_buffer = tcp_buffer.upper()
     traffic_domain = module.params["traffic_domain"]
     if traffic_domain:
         traffic_domain = str(traffic_domain)
     else:
         traffic_domain = "0"
-
+    use_client_ip = module.params["use_client_ip"]
+    if use_client_ip:
+        use_client_ip = use_client_ip.upper()
+    use_proxy_port = module.params["use_proxy_port"]
+    if use_proxy_port:
+        use_proxy_port = use_proxy_port.upper()
 
     args = dict(
+        cip=client_header_state,
+        cipheader=module.params["client_header"],
+        cka=client_keepalive,
         clttimeout=client_timeout,
+        cmp=compression,
         comment=module.params["comment"],
         maxclient=max_client,
         maxreq=max_req,
@@ -1248,14 +1278,10 @@ def main():
         servicetype=service_type,
         servicegroupname=module.params["servicegroup_name"],
         state=servicegroup_state,
+        tcpb=tcp_buffer,
         td=traffic_domain,
-        cka=module.params["cka"],
-        cip=module.params["cip"],
-        cipheader=module.params["cipheader"],
-        usip=module.params["usip"],
-        useproxyport=module.params["useproxyport"],
-        tcpb=module.params["tcpb"],
-        cmp=module.params["cmp"]
+        usip=use_client_ip,
+        useproxyport=use_proxy_port
     )
 
     # check for required values, this allows all values to be passed in provider

--- a/library/netscaler_servicegroup.py
+++ b/library/netscaler_servicegroup.py
@@ -171,6 +171,12 @@ options:
     required: false
     type: str
     choices: ["YES", "NO"]
+  tcpb:
+    description:
+      - Enable TCP buffering for the service group.
+    required: false
+    type: str
+    choices: ["YES", "NO"]
 '''
 
 EXAMPLES = '''
@@ -972,7 +978,8 @@ def main():
         cka=dict(choices=["YES","NO"], required=False, type="str"),
         cip=dict(choices=["ENABLED","DISABLED"], required=False, type="str"),
         usip=dict(choices=["YES","NO"], required=False, type="str", default="NO"),
-        useproxyport=dict(choices=["YES","NO"], required=False, type="str")
+        useproxyport=dict(choices=["YES","NO"], required=False, type="str"),
+        tcpb=dict(choices=["YES","NO"], required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -1011,6 +1018,7 @@ def main():
         cip=module.params["cip"],
         usip=module.params["usip"],
         useproxyport=module.params["useproxyport"],
+        tcpb=module.params["tcpb"]
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args

--- a/library/netscaler_servicegroup.py
+++ b/library/netscaler_servicegroup.py
@@ -177,6 +177,12 @@ options:
     required: false
     type: str
     choices: ["YES", "NO"]
+  cmp:
+    description:
+      - Enable compression for the specified service.
+    required: false
+    type: str
+    choices: ["YES", "NO"]
 '''
 
 EXAMPLES = '''
@@ -979,7 +985,8 @@ def main():
         cip=dict(choices=["ENABLED","DISABLED"], required=False, type="str"),
         usip=dict(choices=["YES","NO"], required=False, type="str", default="NO"),
         useproxyport=dict(choices=["YES","NO"], required=False, type="str"),
-        tcpb=dict(choices=["YES","NO"], required=False, type="str")
+        tcpb=dict(choices=["YES","NO"], required=False, type="str"),
+        cmp=dict(choices=["YES","NO"], required=False, type="str")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -1018,7 +1025,8 @@ def main():
         cip=module.params["cip"],
         usip=module.params["usip"],
         useproxyport=module.params["useproxyport"],
-        tcpb=module.params["tcpb"]
+        tcpb=module.params["tcpb"],
+        cmp=module.params["cmp"]
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args

--- a/library/netscaler_servicegroup.py
+++ b/library/netscaler_servicegroup.py
@@ -156,6 +156,12 @@ options:
     required: false
     type: str
     choices: ["ENABLED", "DISABLED"]
+  usip:
+    description:
+      - Use client's IP address as the source IP address when initiating connection to the server.
+    required: false
+    type: str
+    default: "NO"
 '''
 
 EXAMPLES = '''
@@ -955,7 +961,8 @@ def main():
         servicegroup_state=dict(choices=["disabled", "enabled"], default="enabled", type="str"),
         traffic_domain=dict(required=False, type="str", default="0"),
         cka=dict(choices=["YES","NO"], required=False, type="str"),
-        cip=dict(choices=["ENABLED","DISABLED"], required=False, type="str")
+        cip=dict(choices=["ENABLED","DISABLED"], required=False, type="str"),
+        usip=dict(choices=["YES","NO"], required=False, type="str", default="NO")
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=True)
@@ -991,7 +998,8 @@ def main():
         state=module.params["servicegroup_state"].upper(),
         td=module.params["traffic_domain"],
         cka=module.params["cka"],
-        cip=module.params["cip"]
+        cip=module.params["cip"],
+        usip=module.params["usip"]
     )
 
     # "if isinstance(v, bool) or v" should be used if a bool variable is added to args


### PR DESCRIPTION
This pull request consists of a few more API options :

lbvserver : 
- appflowlog

servicegroup :
- cka
- cip
- usip
- useproxyport
- tcpb
- cmp
- cipheader

lbmonitor :
- send
- recv
- lrtm
- interval
- resptimeout
- retries

And also a fix for checking IP/td/port before IP/td/servicetype (commit cb09072 is commented)